### PR TITLE
Updating some cops to explore alternatives to use them in our current implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,9 @@ All the significant changes to this gem will be documented in this file.
 ### Overview
 - Disabling these cops: Style/ClassAndModuleChildren, RSpec/FactoryBot/SyntaxMethods, Rails/DotSeparatedKeys, Rails/Delegate, RSpec/ExampleLength
 - Enabling these cops: Style/StringLiterals
+
+## 0.1.5 - 2023/07/10
+### Overview
+- Disabling these cops: RSpec/FilePath, RSpec/DescribeMethod
+- Enabling these cops: Rails/DotSeparatedKeys
+- Also enforcing double quotes for StringLiterals

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nfg_rubocop (0.1.3)
+    nfg_rubocop (0.1.5)
       rubocop (~> 1.36.0)
       rubocop-rails
       rubocop-rspec
@@ -9,23 +9,25 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.0.4)
+    activesupport (7.0.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     ast (2.4.2)
-    concurrent-ruby (1.1.10)
-    i18n (1.12.0)
+    concurrent-ruby (1.2.2)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
-    minitest (5.17.0)
-    parallel (1.22.1)
-    parser (3.2.0.0)
+    minitest (5.18.1)
+    parallel (1.23.0)
+    parser (3.2.2.3)
       ast (~> 2.4.1)
-    rack (3.0.3)
+      racc
+    racc (1.7.1)
+    rack (3.0.8)
     rainbow (3.1.1)
-    regexp_parser (2.6.1)
+    regexp_parser (2.8.1)
     rexml (3.2.5)
     rubocop (1.36.0)
       json (~> 2.3)
@@ -37,18 +39,18 @@ GEM
       rubocop-ast (>= 1.20.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.24.1)
-      parser (>= 3.1.1.0)
-    rubocop-rails (2.17.4)
+    rubocop-ast (1.29.0)
+      parser (>= 3.2.1.0)
+    rubocop-rails (2.20.2)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
-    rubocop-rspec (2.16.0)
+    rubocop-rspec (2.17.1)
       rubocop (~> 1.33)
-    ruby-progressbar (1.11.0)
-    tzinfo (2.0.5)
+    ruby-progressbar (1.13.0)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    unicode-display_width (2.4.0)
+    unicode-display_width (2.4.2)
 
 PLATFORMS
   ruby

--- a/config/default.yml
+++ b/config/default.yml
@@ -8,6 +8,7 @@ Bundler/OrderedGems:
 
 Style/StringLiterals:
   Enabled: true
+  EnforcedStyle: double_quotes
 
 Style/Documentation:
   Enabled: false

--- a/config/ext/rails.yml
+++ b/config/ext/rails.yml
@@ -4,6 +4,6 @@ require:
   - rubocop-rails
 
 Rails/DotSeparatedKeys:
-  Enabled: false
+  Enabled: true
 Rails/Delegate:
   Enabled: false

--- a/config/ext/rspec.yml
+++ b/config/ext/rspec.yml
@@ -45,3 +45,7 @@ RSpec/MultipleMemoizedHelpers:
   Enabled: false
 RSpec/ExampleLength:
   Enabled: false
+RSpec/FilePath:
+  Enabled: false
+RSpec/DescribeMethod:
+  Enabled: false

--- a/lib/nfg_rubocop/version.rb
+++ b/lib/nfg_rubocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NfgRubocop
-  VERSION = '0.1.4'
+  VERSION = '0.1.5'
 end


### PR DESCRIPTION
## 0.1.5 - 2023/07/10
### Overview
- Disabling these cops: RSpec/FilePath, RSpec/DescribeMethod
- Enabling these cops: Rails/DotSeparatedKeys
- Also enforcing double quotes for StringLiterals